### PR TITLE
Re-enable Stryker mutation testing in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         recreate: true
         path: code-coverage-results.md
-#    - name: Install dotnet-stryker globally
-#      run: dotnet tool install -g dotnet-stryker
-#    - name: Run mutation test
-#      run: dotnet stryker --mutation-level Complete --break-at ${{ env.MUTATION_THRESHOLD }}
+    - name: Install dotnet-stryker globally
+      run: dotnet tool install -g dotnet-stryker
+    - name: Run mutation test
+      run: dotnet stryker --mutation-level Complete --break-at ${{ env.MUTATION_THRESHOLD }}


### PR DESCRIPTION
Uncomments the Stryker mutation testing steps in `.github/workflows/build-and-test.yml` now that .NET 10 support is available.

Closes #105