### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.Primitives.Bool.Operations/Pure.Primitives.Bool.Operations.csproj
+++ b/src/Pure.Primitives.Bool.Operations/Pure.Primitives.Bool.Operations.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Pure.Primitives.Abstractions" Version="4.3.0" />


### PR DESCRIPTION
Closes #114

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.